### PR TITLE
libstdc++: PSTL dispatch for C++20 range random access iterators

### DIFF
--- a/libstdc++-v3/include/pstl/execution_impl.h
+++ b/libstdc++-v3/include/pstl/execution_impl.h
@@ -20,12 +20,17 @@ namespace __pstl
 namespace __internal
 {
 
-template <typename _IteratorTag, typename... _IteratorTypes>
-using __are_iterators_of = std::conjunction<
-    std::is_base_of<_IteratorTag, typename std::iterator_traits<std::decay_t<_IteratorTypes>>::iterator_category>...>;
-
 template <typename... _IteratorTypes>
-using __are_random_access_iterators = __are_iterators_of<std::random_access_iterator_tag, _IteratorTypes...>;
+using __are_random_access_iterators = std::conjunction<
+#if __cplusplus >= 202002L
+    std::__or_<
+        std::is_base_of<std::random_access_iterator_tag, typename std::iterator_traits<std::__remove_cvref_t<_IteratorTypes>>::iterator_category>,
+        std::integral_constant<bool, std::random_access_iterator<_IteratorTypes>>
+    >...
+#else   // __cplusplus
+        std::is_base_of<std::random_access_iterator_tag, typename std::iterator_traits<std::__remove_cvref_t<_IteratorTypes>>::iterator_category>...
+#endif  // __cplusplus
+>;
 
 struct __serial_backend_tag
 {


### PR DESCRIPTION
This patch closes 110512, in which random access iterators originated from C++20 ranges are dispatched to the sequential algorithms in the parallel STL because, before this patch, the parallel STL checks whether an iterator inherits from the random access iterator tag. This patch extends the check in C++ >= 20 to also check whether the iterator models the std::random_access_iterator concept. This is allowed by C++23's P2408, which is safe to backport to C++20 because any application that would break already exhibits undefined behavior due to pre-condition violation.